### PR TITLE
ci: pin Wrangler compatibility date

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,4 @@
+# Keep this date aligned with the newest compatibility date supported by the
+# Wrangler version pinned in pnpm-lock.yaml. Update it periodically as Wrangler
+# releases add support for newer Cloudflare Workers runtime dates.
+compatibility_date = "2026-08-08"


### PR DESCRIPTION
## Summary
- Add a Wrangler configuration file with a pinned `compatibility_date` of `2026-08-08`.
- Document that the date should be periodically advanced as the locked Wrangler/workerd version gains support for newer runtime dates.

## Context
The Dependabot PRs #2224 and #2225 failed before Playwright startup because Wrangler defaulted to the current date (`2026-08-14`), while the locked workerd binary supported dates only through `2026-08-08`. This configuration is read by `wrangler pages dev` and the Pages deployment command.

## Validation
- `pnpm install --frozen-lockfile`
- Local Wrangler Pages server started successfully and returned HTTP 200.
- `pnpm exec playwright test --project=chromium` — 9 passed.
- `pnpm run build` — passed.
- Full multi-browser Playwright run was attempted; Firefox/WebKit are blocked locally by missing host libraries, while CI installs those dependencies with `playwright install --with-deps`.
