### PR TITLE
ci: configure Pages build output directory

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 # Keep this date aligned with the newest compatibility date supported by the
 # Wrangler version pinned in pnpm-lock.yaml. Update it periodically as Wrangler
 # releases add support for newer Cloudflare Workers runtime dates.
+name = "home-page"
 compatibility_date = "2026-08-08"
 pages_build_output_dir = "./src"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,3 +2,4 @@
 # Wrangler version pinned in pnpm-lock.yaml. Update it periodically as Wrangler
 # releases add support for newer Cloudflare Workers runtime dates.
 compatibility_date = "2026-08-08"
+pages_build_output_dir = "./src"


### PR DESCRIPTION
## Summary
- Set `pages_build_output_dir` to `./src` in `wrangler.toml`.
- Allow Wrangler to use the repository configuration for Pages deployments without warnings.

## Context
The successful Dependabot workflows reported that Pages detected `wrangler.toml` but ignored it because `pages_build_output_dir` was missing. The existing workflow builds and deploys the static site from `src`.

## Validation
- Local Wrangler Pages server started successfully and returned HTTP 200.
- `pnpm exec playwright test --project=chromium` — 9 passed.
- `pnpm run build` — passed.
- `git diff --check` — passed.
