### PR TITLE
fix: run Playwright server through Corepack

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,7 +72,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm run start',
+    command: 'corepack pnpm exec wrangler pages dev src --port 8788',
     url: 'http://localhost:8788',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
## Summary
- Run the Playwright web server command through Corepack
- Invoke Wrangler directly so nested package scripts do not depend on a global pnpm binary

## Test plan
- `corepack pnpm exec playwright test --project=chromium --reporter=line` — 9 passed
- Full browser suite starts successfully; WebKit remains unavailable locally because the host is missing its system libraries
